### PR TITLE
pin arrow to git version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,8 +49,7 @@ checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
 [[package]]
 name = "arrow"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc25126d18a012146a888a0298f2c22e1150327bd2765fc76d710a556b2d614"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "ahash",
  "arrow-arith",
@@ -69,8 +68,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ccd45e217ffa6e53bbb0080990e77113bdd4e91ddb84e97b77649810bcf1a7"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -84,8 +82,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bda9acea48b25123c08340f3a8ac361aa0f74469bb36f5ee9acf923fce23e9d"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -100,8 +97,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a0fc21915b00fc6c2667b069c1b64bdd920982f426079bc4a7cab86822886c"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "bytes",
  "half",
@@ -111,8 +107,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc0368ed618d509636c1e3cc20db1281148190a78f43519487b2daf07b63b4a"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -129,8 +124,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907fafe280a3874474678c1858b9ca4cb7fd83fb8034ff5b6d6376205a08c634"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -151,8 +145,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a43d6808411886b8c7d4f6f7dd477029c1e77ffffffb7923555cc6579639cd"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -165,8 +158,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b23b0e53c0db57c6749997fd343d4c0354c994be7eca67152dd2bdb9a3e1bb4"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -180,8 +172,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361249898d2d6d4a6eeb7484be6ac74977e48da12a4dd81a708d620cc558117a"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -195,8 +186,7 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e28a5e781bf1b0f981333684ad13f5901f4cd2f20589eab7cf1797da8fc167"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "bitflags 2.4.1",
 ]
@@ -204,8 +194,7 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6208466590960efc1d2a7172bc4ff18a67d6e25c529381d7f96ddaf0dc4036"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -218,8 +207,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a48149c63c11c9ff571e50ab8f017d2a7cb71037a882b42f6354ed2da9acc7"
+source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,12 @@ js-sys = "0.3.60"
 getrandom = { version = "0.2.6", features = ["js"] }
 thiserror = "1.0"
 
-arrow2 = { version = "0.18", optional = true, features = [
-  "io_ipc",
-] }
+arrow2 = { version = "0.18", optional = true, features = ["io_ipc"] }
 
-arrow-schema = { version = "49", optional = true }
-arrow = { version = "49", default-features = false, optional = true, features = [
+# Temporary for compatibility with geoarrow-rs until next release
+#
+arrow-schema = { git = "https://github.com/apache/arrow-rs", rev = "fbbb61d94282165f9bb9f73fb4d00a3af16d4aee", optional = true }
+arrow = { git = "https://github.com/apache/arrow-rs", rev = "fbbb61d94282165f9bb9f73fb4d00a3af16d4aee", default-features = false, optional = true, features = [
   "ffi",
   "ipc",
 ] }


### PR DESCRIPTION
fixes interoperability with geoarrow-rs until next arrow-rs release.