### PR TITLE
Restore FFIData and FFIVector

### DIFF
--- a/src/ffi/data.rs
+++ b/src/ffi/data.rs
@@ -1,0 +1,95 @@
+use arrow::array::Array;
+use arrow::ffi;
+use wasm_bindgen::prelude::*;
+
+use crate::error::Result;
+use crate::ffi::{FFIArrowArray, FFIArrowSchema};
+
+/// An Arrow array including associated field metadata.
+///
+/// Using [`arrow-js-ffi`](https://github.com/kylebarron/arrow-js-ffi), you can view or copy Arrow
+/// these objects to JavaScript.
+///
+
+// TODO: fix example
+// ```ts
+// import { parseField, parseVector } from "arrow-js-ffi";
+//
+// // You need to access the geoarrow webassembly memory space.
+// // The way to do this is different per geoarrow bundle method.
+// const WASM_MEMORY: WebAssembly.Memory = geoarrow.__wasm.memory;
+//
+// // Say we have a point array from somewhere
+// const pointArray: geoarrow.PointArray = ...;
+//
+// // Export this existing point array to wasm.
+// const ffiArray = pointArray.toFfi();
+//
+// // Parse an arrow-js field object from the pointer
+// const jsArrowField = parseField(WASM_MEMORY.buffer, ffiArray.field_addr());
+//
+// // Parse an arrow-js vector from the pointer and parsed field
+// const jsPointVector = parseVector(
+//   WASM_MEMORY.buffer,
+//   ffiArray.array_addr(),
+//   field.type
+// );
+// ```
+//
+// ## Memory management
+//
+// Note that this array will not be released automatically. You need to manually call `.free()` to
+// release memory.
+#[wasm_bindgen]
+pub struct FFIData {
+    array: FFIArrowArray,
+    field: FFIArrowSchema,
+}
+
+impl FFIData {
+    pub fn from_raw(array: FFIArrowArray, field: FFIArrowSchema) -> Self {
+        Self { field, array }
+    }
+
+    /// Construct an [FFIData] from an Arrow array and optionally a field.
+    ///
+    /// In the Rust Arrow implementation, arrays do not store associated fields, so exporting an
+    /// `Arc<dyn Array>` to this [`FFIData`] will infer a "default field" for the given data type.
+    /// This is not sufficient for some Arrow data, such as with extension types, where custom
+    /// field metadata is required.
+    pub fn from_arrow(array: &dyn Array, field: Option<impl Into<FFIArrowSchema>>) -> Result<Self> {
+        let (ffi_array, ffi_schema) = ffi::to_ffi(&array.to_data())?;
+        let ffi_schema = field
+            .map(|f| f.into())
+            .unwrap_or_else(|| Box::new(ffi_schema).into());
+        Ok(Self {
+            field: ffi_schema,
+            array: Box::new(ffi_array).into(),
+        })
+    }
+}
+
+impl TryFrom<&dyn Array> for FFIData {
+    type Error = crate::error::ArrowWasmError;
+
+    fn try_from(value: &dyn Array) -> Result<Self> {
+        let (ffi_array, ffi_schema) = ffi::to_ffi(&value.to_data())?;
+        Ok(Self {
+            field: Box::new(ffi_schema).into(),
+            array: Box::new(ffi_array).into(),
+        })
+    }
+}
+
+#[wasm_bindgen]
+impl FFIData {
+    #[wasm_bindgen(js_name = arrayAddr)]
+    pub fn array_addr(&self) -> *const ffi::FFI_ArrowArray {
+        self.array.addr()
+    }
+
+    #[wasm_bindgen]
+    pub fn schema_addr(&self) -> *const ffi::FFI_ArrowSchema {
+        self.field.addr()
+    }
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,8 +1,12 @@
 pub mod array;
+pub mod data;
 pub mod record_batch;
 pub mod schema;
 pub mod table;
+pub mod vector;
 
 pub use array::FFIArrowArray;
+pub use data::FFIData;
 pub use record_batch::FFIRecordBatch;
 pub use schema::FFIArrowSchema;
+pub use vector::FFIVector;

--- a/src/ffi/vector.rs
+++ b/src/ffi/vector.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use arrow::array::Array;
+use arrow::ffi;
+use wasm_bindgen::prelude::*;
+
+use crate::error::{Result, WasmResult};
+use crate::ffi::FFIArrowSchema;
+
+/// A chunked Arrow array including associated field metadata
+#[wasm_bindgen]
+pub struct FFIVector {
+    field: FFIArrowSchema,
+    chunks: Vec<ffi::FFI_ArrowArray>,
+}
+
+impl FFIVector {
+    pub fn from_raw(field: FFIArrowSchema, chunks: Vec<ffi::FFI_ArrowArray>) -> Self {
+        Self { field, chunks }
+    }
+
+    /// Construct an FFIVector from array chunks and optionally from the provided field.
+    ///
+    /// For now, the field is inferred from the first chunk if not provided.
+    ///
+    // TODO: validate that each chunk has the same data types?
+    pub fn from_arrow(
+        chunks: Vec<Arc<dyn Array>>,
+        field: Option<impl Into<FFIArrowSchema>>,
+    ) -> Result<Self> {
+        let mut ffi_field: Option<FFIArrowSchema> = field.map(|f| f.into());
+        let mut ffi_chunks = Vec::with_capacity(chunks.len());
+
+        for chunk in chunks {
+            let (ffi_array, ffi_schema) = ffi::to_ffi(&chunk.to_data())?;
+            if ffi_field.is_none() {
+                ffi_field = Some(FFIArrowSchema::new(Box::new(ffi_schema)));
+            }
+            ffi_chunks.push(ffi_array);
+        }
+
+        Ok(Self {
+            field: ffi_field.unwrap(),
+            chunks: ffi_chunks,
+        })
+    }
+}
+
+#[wasm_bindgen]
+impl FFIVector {
+    #[wasm_bindgen(js_name = schemaAddr)]
+    pub fn schema_addr(&self) -> *const ffi::FFI_ArrowSchema {
+        self.field.addr()
+    }
+
+    #[wasm_bindgen(js_name = arrayAddr)]
+    pub fn array_addr(&self, i: usize) -> WasmResult<*const ffi::FFI_ArrowArray> {
+        Ok(self.chunks.get(i).unwrap() as *const _)
+    }
+}


### PR DESCRIPTION
These were removed in https://github.com/kylebarron/arrow-wasm/pull/63 but really are necessary to store an array and an associated field in the same object.