### PR TITLE
Minimize arrow crate dependency surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,15 +17,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,39 +29,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "arrow"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ec52ba94edeed950e4a41f75d35376df196e8cb04437f7280a5aa49f20f796"
-dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc766fdacaf804cb10c7c70580254fcdb5d55cdfda2bc57b02baf5223a3af9e"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "num",
 ]
 
 [[package]]
@@ -101,26 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-cast"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede6175fbc039dfc946a61c1b6d42fd682fcecf5ab5d148fbe7667705798cac9"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "atoi",
- "base64",
- "chrono",
- "half",
- "lexical-core",
- "num",
- "ryu",
-]
-
-[[package]]
 name = "arrow-data"
 version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,76 +84,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-ord"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a3334a743bd2a1479dbc635540617a3923b4b2f6870f37357339e6b5363c21"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
-]
-
-[[package]]
-name = "arrow-row"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1d7a7291d2c5107e92140f75257a99343956871f3d3ab33a7b41532f79cb68"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "half",
-]
-
-[[package]]
 name = "arrow-schema"
 version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 dependencies = [
- "bitflags 2.6.0",
-]
-
-[[package]]
-name = "arrow-select"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69efcd706420e52cd44f5c4358d279801993846d1c2a8e52111853d61d55a619"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num",
-]
-
-[[package]]
-name = "arrow-string"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21546b337ab304a32cfc0770f671db7411787586b45b78b4593ae78e64e2b03"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "memchr",
- "num",
- "regex",
- "regex-syntax",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
 name = "arrow-wasm"
 version = "0.1.0"
 dependencies = [
- "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
  "arrow-schema",
  "console_error_panic_hook",
  "getrandom",
@@ -228,25 +112,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
@@ -256,9 +125,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bumpalo"
@@ -268,9 +137,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -337,9 +206,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "flatbuffers"
@@ -366,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -383,14 +252,15 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -421,70 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical-core"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431c65b318a590c1de6b8fd6e72798c92291d27762d94c9e6c37ed7a73d8458"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb17a4bdb9b418051aa59d41d65b1c9be5affab314a872e5ad7f06231fb3b4e0"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df98f4a4ab53bf8b175b363a34c7af608fe31f93cc1fb1bf07130622ca4ef61"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85314db53332e5c192b6bca611fb10c114a80d1b831ddac0af1e9be1b9232ca0"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7c3ad4e37db81c1cbe7cf34610340adc09c322871972f74877a712abc6c809"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb89e9f6958b83258afa3deed90b5de9ef68eef090ad5086c791cd2345610162"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,9 +298,9 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "log"
@@ -617,35 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -729,12 +506,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -922,11 +693,37 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -934,6 +731,24 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,11 @@ js-sys = "0.3.77"
 getrandom = { version = "0.2.15", features = ["js"] }
 thiserror = "2.0"
 
-arrow-schema = "54"
-arrow = { version = "54", default-features = false, features = ["ffi", "ipc"] }
+arrow-array = { version = "54.3", features = ["ffi"] }
+arrow-buffer = "54.3"
+arrow-data = "54.3"
+arrow-ipc = "54.3"
+arrow-schema = "54.3"
 
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/src/arrow_js/data.rs
+++ b/src/arrow_js/data.rs
@@ -1,5 +1,5 @@
-use arrow::array::*;
-use arrow::buffer::Buffer;
+use arrow_buffer::Buffer;
+use arrow_data::ArrayData;
 use arrow_schema::DataType;
 use wasm_bindgen::prelude::*;
 

--- a/src/arrow_js/record_batch.rs
+++ b/src/arrow_js/record_batch.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use crate::error::WasmResult;
-use arrow::array::{make_array, AsArray};
+use arrow_array::cast::AsArray;
+use arrow_array::make_array;
 use arrow_schema::SchemaRef;
 // use arrow::record_batch::RecordBatch;
 use crate::record_batch::RecordBatch;
@@ -29,10 +30,8 @@ impl RecordBatch {
         let dyn_arr = make_array(data);
         let struct_arr = dyn_arr.as_struct();
 
-        let batch = arrow::record_batch::RecordBatch::try_new(
-            Arc::new(schema),
-            struct_arr.columns().to_vec(),
-        )?;
+        let batch =
+            arrow_array::RecordBatch::try_new(Arc::new(schema), struct_arr.columns().to_vec())?;
         Ok(RecordBatch::new(batch))
     }
 
@@ -44,8 +43,7 @@ impl RecordBatch {
         let dyn_arr = make_array(data);
         let struct_arr = dyn_arr.as_struct();
 
-        let batch =
-            arrow::record_batch::RecordBatch::try_new(schema, struct_arr.columns().to_vec())?;
+        let batch = arrow_array::RecordBatch::try_new(schema, struct_arr.columns().to_vec())?;
         Ok(RecordBatch::new(batch))
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use arrow::array::AsArray;
-use arrow::array::{make_array, Array, ArrayRef};
-use arrow::datatypes::{
+use arrow_array::cast::AsArray;
+use arrow_array::types::{
     Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
     UInt64Type, UInt8Type,
 };
+use arrow_array::{make_array, Array, ArrayRef};
 use arrow_schema::DataType;
 use arrow_schema::{Field, FieldRef};
 use wasm_bindgen::prelude::*;
@@ -27,8 +27,8 @@ impl Data {
     /// Export this to FFI.
     #[wasm_bindgen(js_name = toFFI)]
     pub fn to_ffi(&self) -> WasmResult<FFIData> {
-        let ffi_schema = arrow::ffi::FFI_ArrowSchema::try_from(&self.field)?;
-        let ffi_array = arrow::ffi::FFI_ArrowArray::new(&self.array.to_data());
+        let ffi_schema = arrow_array::ffi::FFI_ArrowSchema::try_from(&self.field)?;
+        let ffi_array = arrow_array::ffi::FFI_ArrowArray::new(&self.array.to_data());
         Ok(FFIData::new(Box::new(ffi_array), Box::new(ffi_schema)))
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use arrow::error::ArrowError;
+use arrow_schema::ArrowError;
 use thiserror::Error;
 use wasm_bindgen::JsError;
 

--- a/src/ffi/chunked.rs
+++ b/src/ffi/chunked.rs
@@ -1,4 +1,4 @@
-use arrow::ffi;
+use arrow_array::ffi;
 use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::*;
 

--- a/src/ffi/data.rs
+++ b/src/ffi/data.rs
@@ -1,5 +1,4 @@
-use arrow::array::{Array, StructArray};
-use arrow::ffi;
+use arrow_array::{ffi, Array, StructArray};
 use arrow_schema::{ArrowError, Field};
 use wasm_bindgen::prelude::*;
 
@@ -61,10 +60,10 @@ impl FFIData {
     /// field metadata is required.
     pub fn from_arrow(
         array: &dyn Array,
-        field: impl TryInto<arrow::ffi::FFI_ArrowSchema, Error = ArrowError>,
+        field: impl TryInto<arrow_array::ffi::FFI_ArrowSchema, Error = ArrowError>,
     ) -> Result<Self> {
-        let ffi_field: arrow::ffi::FFI_ArrowSchema = field.try_into()?;
-        let ffi_array = arrow::ffi::FFI_ArrowArray::new(&array.to_data());
+        let ffi_field: arrow_array::ffi::FFI_ArrowSchema = field.try_into()?;
+        let ffi_array = arrow_array::ffi::FFI_ArrowArray::new(&array.to_data());
 
         Ok(Self {
             array: Box::new(ffi_array),
@@ -86,12 +85,10 @@ impl TryFrom<&dyn Array> for FFIData {
     }
 }
 
-impl TryFrom<&arrow::record_batch::RecordBatch> for FFIData {
+impl TryFrom<&arrow_array::RecordBatch> for FFIData {
     type Error = ArrowWasmError;
 
-    fn try_from(
-        value: &arrow::record_batch::RecordBatch,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: &arrow_array::RecordBatch) -> std::result::Result<Self, Self::Error> {
         let field = Field::new_struct("", value.schema_ref().fields().clone(), false);
         let data = StructArray::from(value.clone());
         Self::from_arrow(&data, field)

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -1,4 +1,4 @@
-use arrow::ffi;
+use arrow_array::ffi;
 use arrow_schema::ArrowError;
 use wasm_bindgen::prelude::*;
 
@@ -19,9 +19,9 @@ impl FFISchema {
     /// This is not sufficient for some Arrow data, such as with extension types, where custom
     /// field metadata is required.
     pub fn from_arrow(
-        field: impl TryInto<arrow::ffi::FFI_ArrowSchema, Error = ArrowError>,
+        field: impl TryInto<arrow_array::ffi::FFI_ArrowSchema, Error = ArrowError>,
     ) -> Result<Self> {
-        let ffi_field: arrow::ffi::FFI_ArrowSchema = field.try_into()?;
+        let ffi_field: arrow_array::ffi::FFI_ArrowSchema = field.try_into()?;
         Ok(Self::new(Box::new(ffi_field)))
     }
 }

--- a/src/record_batch.rs
+++ b/src/record_batch.rs
@@ -5,14 +5,14 @@ use wasm_bindgen::prelude::*;
 
 /// A group of columns of equal length in WebAssembly memory with an associated {@linkcode Schema}.
 #[wasm_bindgen]
-pub struct RecordBatch(arrow::record_batch::RecordBatch);
+pub struct RecordBatch(arrow_array::RecordBatch);
 
 impl RecordBatch {
-    pub fn new(batch: arrow::record_batch::RecordBatch) -> Self {
+    pub fn new(batch: arrow_array::RecordBatch) -> Self {
         Self(batch)
     }
 
-    pub fn into_inner(self) -> arrow::record_batch::RecordBatch {
+    pub fn into_inner(self) -> arrow_array::RecordBatch {
         self.0
     }
 }
@@ -89,13 +89,13 @@ impl RecordBatch {
     }
 }
 
-impl From<arrow::record_batch::RecordBatch> for RecordBatch {
-    fn from(value: arrow::record_batch::RecordBatch) -> Self {
+impl From<arrow_array::RecordBatch> for RecordBatch {
+    fn from(value: arrow_array::RecordBatch) -> Self {
         Self(value)
     }
 }
 
-impl From<RecordBatch> for arrow::record_batch::RecordBatch {
+impl From<RecordBatch> for arrow_array::RecordBatch {
     fn from(value: RecordBatch) -> Self {
         value.0
     }
@@ -117,8 +117,8 @@ impl TryFrom<&RecordBatch> for FFIData {
     }
 }
 
-impl AsRef<arrow::record_batch::RecordBatch> for RecordBatch {
-    fn as_ref(&self) -> &arrow::record_batch::RecordBatch {
+impl AsRef<arrow_array::RecordBatch> for RecordBatch {
+    fn as_ref(&self) -> &arrow_array::RecordBatch {
         &self.0
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,4 @@
-use arrow::ipc::writer::StreamWriter;
+use arrow_ipc::writer::StreamWriter;
 use std::collections::HashMap;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,10 +1,10 @@
 use crate::error::WasmResult;
 use crate::ffi::{FFISchema, FFIStream};
 use crate::ArrowWasmError;
-use arrow::array::{Array, StructArray};
-use arrow::ffi;
-use arrow::ipc::reader::StreamReader;
-use arrow::ipc::writer::StreamWriter;
+use arrow_array::ffi;
+use arrow_array::{Array, StructArray};
+use arrow_ipc::reader::StreamReader;
+use arrow_ipc::writer::StreamWriter;
 use std::io::Cursor;
 use wasm_bindgen::prelude::*;
 
@@ -16,24 +16,16 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct Table {
     schema: arrow_schema::SchemaRef,
-    batches: Vec<arrow::record_batch::RecordBatch>,
+    batches: Vec<arrow_array::RecordBatch>,
 }
 
 impl Table {
-    pub fn new(
-        schema: arrow_schema::SchemaRef,
-        batches: Vec<arrow::record_batch::RecordBatch>,
-    ) -> Self {
+    pub fn new(schema: arrow_schema::SchemaRef, batches: Vec<arrow_array::RecordBatch>) -> Self {
         Self { schema, batches }
     }
 
     /// Consume this table and return its components
-    pub fn into_inner(
-        self,
-    ) -> (
-        arrow_schema::SchemaRef,
-        Vec<arrow::record_batch::RecordBatch>,
-    ) {
+    pub fn into_inner(self) -> (arrow_schema::SchemaRef, Vec<arrow_array::RecordBatch>) {
         (self.schema, self.batches)
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use arrow::array::ArrayRef;
+use arrow_array::ArrayRef;
 use arrow_schema::{ArrowError, DataType, Field, FieldRef};
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
Don't depend on `arrow`; instead depend on individual arrow crates for a smaller dependency tree and faster compile times.