### PR TITLE
chore: add release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,52 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'kylebarron' }}
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write
+    steps:
+      - &checkout
+        name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - &install-rust
+        name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'kylebarron' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - *checkout
+      - *install-rust
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Simple setup for [release-plz](https://release-plz.dev), which is a [release-please](https://github.com/googleapis/release-please) equivalent that's good at Rust crates. To actually get publishing working, we'll want to do a couple of things before merging this PR:

1. Do an initial `cargo publish` for v0.1.0. I could do and then add @kylebarron as an owner, unless you'd like to do it yourself.
2. Set up trusted publishing in crates.io
3. (optional) Set up a Github app or PAT and use that for the workflow, so the **release-plz** PRs can trigger other Github actions ([ref](https://release-plz.dev/docs/github/token). If we wanted to transfer to https://github.com/developmentseed/ first, there's already an app set up to do that, up to you

Once we do that, we can merge this PR and get automated version PRs.